### PR TITLE
Update class name to match recent upstream changes

### DIFF
--- a/googlereaderkeys/init.php
+++ b/googlereaderkeys/init.php
@@ -1,5 +1,5 @@
 <?php
-class GoogleReaderKeysDWC extends Plugin {
+class GoogleReaderKeys extends Plugin {
 	private $host;
 
 	function about() {


### PR DESCRIPTION
It appears that at some point recently the class name needed to match the folder that the plugin was in (see the [upstream documentation](https://git.tt-rss.org/fox/tt-rss/wiki/Plugins#installing-plugins) for more details).